### PR TITLE
Fix worker & bridge cleanup logic

### DIFF
--- a/src/mlops/cluster/worker_bridge.py
+++ b/src/mlops/cluster/worker_bridge.py
@@ -94,14 +94,15 @@ class WorkerBridgeFactory(WorkerBridgeFactoryBase):
 
     def __init__(self):
         self._cached_bridges = {}
-        self._clean_thread = threading.Thread(target=self._clean)
+        self._clean_thread = threading.Thread(target=self._clean, daemon=True)
         self._close_event = threading.Event()
         self._cache_lock = rwlock.RWLockFair()
+        self._clean_thread.start()
 
     def _clean(self):
         while not self._close_event.wait(0):
             with self._cache_lock.gen_wlock():
-                for key, record in self._cached_bridges.items():
+                for key, record in list(self._cached_bridges.items()):
                     record.breath -= 1
                     if record.breath <= 0:
                         record.bridge.close()


### PR DESCRIPTION
## Summary
- fix worker to record cluster and maintain progress file properly
- fix worker's end task file handling
- start cleanup thread for worker bridges and avoid mutation during iteration

## Testing
- `python -m py_compile src/mlops/cluster/worker_bridge.py src/mlops/worker/testing_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_68502dc3b1748330b05664748367b27d